### PR TITLE
Update to Maximo 7.6.1 image

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Maximo on Docker enables to run Maximo Asset Management on Docker. The images ar
 
 * IBM Maximo Asset Management V7.6 binaries from [Passport Advantage](http://www-01.ibm.com/software/passportadvantage/pao_customer.html)
 
-  IBM Maximo Asset Management V7.6 binaries:
-  * MAM_7.6.0.0_LINUX64.tar.gz
+  IBM Maximo Asset Management V7.6.1 binaries:
+  * MAM_7.6.1_LINUX64.tar.gz
 
   IBM WebSphere Application Server traditional V9 binaries:
   * WAS_ND_V9.0_MP_ML.zip
@@ -32,9 +32,6 @@ Maximo on Docker enables to run Maximo Asset Management on Docker. The images ar
   * DB2_AWSE_REST_Svr_11.1_Lnx_86-64.tar.gz
 
 * Feature Pack/Fix Pack binaries from [Fix Central](http://www-933.ibm.com/support/fixcentral/)
-
-  IBM Maximo Asset Management V7.6 Feature Pack 9 binaries:
-  * MAMMTFP7609IMRepo.zip
 
   IBM WebSphere Application Server traditional Fixpack V9.0.0.7 binaries:
   * 9.0.0-WS-WAS-FP007.zip
@@ -94,7 +91,7 @@ Prereq: all binaries should be accessible via a web server during building phase
     ```
     Build Maximo Asset Management Installation image:
     ```bash
-    docker build -t maximo/maximo:7.6.0.9 -t maximo/maximo:latest --network build maximo
+    docker build -t maximo/maximo:7.6.1 -t maximo/maximo:latest --network build maximo
     ```
     Note: If the build has failed during Maximo Feature Pack installation, run the docker build again.
 7. Run containers by using the Docker Compose file to create and deploy instances:

--- a/maximo/Dockerfile
+++ b/maximo/Dockerfile
@@ -42,18 +42,17 @@ WORKDIR /Launchpad
 
 ENV BYPASS_PRS=True
 
-## Install Maximo V7.6
-ENV MAM_IMAGE MAM_7.6.0.0_LINUX64.tar.gz
-RUN wget -q $url/$MAM_IMAGE && tar zxpf $MAM_IMAGE \
+## Install Maximo V7.6.1
+ENV MAM_IMAGE MAM_7.6.1_LINUX64.tar.gz
+## Remove z from tar command because file is not gzipped despite having gz extension
+RUN wget -q $url/$MAM_IMAGE && tar xpf $MAM_IMAGE \
  && /opt/IBM/InstallationManager/eclipse/tools/imcl \
- -input /Launchpad/SilentResponseFiles/Installer/Unix/ResponseFile_MAM_Install_Unix.xml \
+ -input /Launchpad/SilentResponseFiles/Unix/ResponseFile_MAM_Install_Unix.xml \
  -acceptLicense -log /tmp/MAM_Install_Unix.xml \
  && rm $MAM_IMAGE
 
-## Install Maximo V7.6.0.7 feature packs
 RUN mkdir /work
 WORKDIR /work
-ENV MAM_FP_IMAGE MAMMTFP760${fp}IMRepo.zip
 
 RUN wget -q $url/$MAM_FP_IMAGE && sleep 30 \
  && /opt/IBM/InstallationManager/eclipse/tools/imcl install \


### PR DESCRIPTION
Update the file names.
Update the path to the Unix Response File.

There is a slight bug that I noticed.  When I download the 7.6.1 installation image from IBM it appears to be a `.tar.gz`, however when you try and run the `tar zxpf` command it errors saying that it is _not_ a gzip archive.  The fix is to remove the `-z` from the tar command.

Everything else was straightforward.