### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+group: travis_latest
+language: python
+cache: pip
+matrix:
+  allow_failures:
+    - python: 2.7
+    - python: 3.7
+  include:
+    - python: 2.7
+    #- python: 3.4
+    #- python: 3.5
+    #- python: 3.6
+    - python: 3.7
+      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+      sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+install:
+  # - pip install -r requirements.txt
+  - pip install flake8
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+  - true  # add other tests here
+notifications:
+  on_success: change
+  on_failure: change  # `always` will be the setting once code changes slow down

--- a/maximo/AddVirtualHosts.py
+++ b/maximo/AddVirtualHosts.py
@@ -14,8 +14,14 @@
    limitations under the License.
 """
 
-execfile('/opt/wsadminlib.py')
 
+def load_wsadminlib(filename='/opt/wsadminlib.py'):
+    global addHostAlias, enableDebugMessages, hostAliasExists, save
+    with open(filename) as in_file:
+        exec(in_file.read())
+
+
+load_wsadminlib()
 enableDebugMessages()
 
 if not hostAliasExists('maximo_host', '*', 80):

--- a/maximo/SetAutoRestart.py
+++ b/maximo/SetAutoRestart.py
@@ -14,32 +14,40 @@
    limitations under the License.
 """
 
-execfile('/opt/wsadminlib.py')
+
+def load_wsadminlib(filename='/opt/wsadminlib.py'):
+    global enableDebugMessages, getObjectsOfType, getServerId, listAllAppServers, save
+    global setObjectAttributes, sop
+    with open(filename) as in_file:
+        exec(in_file.read())
+
+
+load_wsadminlib()
+
 
 def setServerAutoRestart(nodename, servername, autorestart, state):
     """Sets whether the nodeagent will automatically restart a failed server.
 
     Specify autorestart='true' or 'false' (as a string)"""
     m = "setServerAutoRestart:"
-    sop(m,"Entry. nodename=%s servername=%s autorestart=%s" % ( nodename, servername, autorestart ))
-    if autorestart != "true" and autorestart != "false":
-        raise m + " Invocation Error: autorestart must be 'true' or 'false'. autorestart=%s" % ( autorestart )
-    server_id = getServerId(nodename,servername)
-    if server_id == None:
-        raise " Error: Could not find server. servername=%s nodename=%s" % (nodename,servername)
-    sop(m,"server_id=%s" % server_id)
+    sop(m, "Entry. nodename=%s servername=%s autorestart=%s" % (nodename, servername, autorestart))
+    if autorestart not in ("true", "false"):
+        raise Exception(m + " Invocation Error: autorestart must be 'true' or 'false'. autorestart=%s" % (autorestart))
+    server_id = getServerId(nodename, servername)
+    if server_id is None:
+        raise Exception(" Error: Could not find server. servername=%s nodename=%s" % (nodename, servername))
+    sop(m, "server_id=%s" % server_id)
     monitors = getObjectsOfType('MonitoringPolicy', server_id)
-    sop(m,"monitors=%s" % ( repr(monitors)) )
+    sop(m, "monitors=%s" % (repr(monitors)))
     if len(monitors) == 1:
-        setObjectAttributes(monitors[0], autoRestart = "%s" % (autorestart))
-        setObjectAttributes(monitors[0], nodeRestartState = "%s" % (state))
+        setObjectAttributes(monitors[0], autoRestart="%s" % (autorestart))
+        setObjectAttributes(monitors[0], nodeRestartState="%s" % (state))
     else:
-        raise m + "ERROR Server has an unexpected number of monitor object(s). monitors=%s" % ( repr(monitors) )
-    sop(m,"Exit.")
+        raise Exception(m + "ERROR Server has an unexpected number of monitor object(s). monitors=%s" % (repr(monitors)))
+    sop(m, "Exit.")
+
 
 enableDebugMessages()
-
 for (nodename, servername) in listAllAppServers():
     setServerAutoRestart(nodename, servername, 'true', 'RUNNING')
-
 save()

--- a/maximo/StartAllServers.py
+++ b/maximo/StartAllServers.py
@@ -14,9 +14,14 @@
    limitations under the License.
 """
 
-execfile('/opt/wsadminlib.py')
 
+def load_wsadminlib(filename='/opt/wsadminlib.py'):
+    global enableDebugMessages, listAllAppServers, startServer
+    with open(filename) as in_file:
+        exec(in_file.read())
+
+
+load_wsadminlib()
 enableDebugMessages()
-
 for (nodename, servername) in listAllAppServers():
     startServer(nodename, servername)

--- a/maximo/StopAllServers.py
+++ b/maximo/StopAllServers.py
@@ -14,9 +14,14 @@
    limitations under the License.
 """
 
-execfile('/opt/wsadminlib.py')
 
+def load_wsadminlib(filename='/opt/wsadminlib.py'):
+    global enableDebugMessages, listAllAppServers, stopServer
+    with open(filename) as in_file:
+        exec(in_file.read())
+
+
+load_wsadminlib()
 enableDebugMessages()
-
 for (nodename, servername) in listAllAppServers():
     stopServer(nodename, servername)

--- a/maxweb/CreateWebServer.py
+++ b/maxweb/CreateWebServer.py
@@ -14,13 +14,17 @@
    limitations under the License.
 """
 
-execfile('/opt/wsadminlib.py')
+import sys
 
-nodeName = sys.argv[0]
-webServerName = sys.argv[1]
-webServerPort = sys.argv[2]
-httpServerHome = sys.argv[3]
-webspherePluginHome = sys.argv[4]
+
+def load_wsadminlib(filename='/opt/wsadminlib.py'):
+    global createWebserver, generatePluginCfg, saveAndSyncAndPrintResult
+    with open(filename) as in_file:
+        exec(in_file.read())
+
+
+load_wsadminlib()
+nodeName, webServerName, webServerPort, httpServerHome, webspherePluginHome = sys.argv[:5]
 
 createWebserver(webServerName, nodeName, webServerPort, httpServerHome, webspherePluginHome,
     httpServerHome + '/conf/httpd.conf', 'ALL', '8008', 'admin', 'password')


### PR DESCRIPTION
__execfile()__ was removed in Python 3.  This PR proposes a solution that works equally well in both Python 2 and Python 3 which also makes explicit with __global__ statements which variables defined in __/opt/wsadminlib.py__ will be used locally.

__raise str__ is not allowed in Python 3 so __raise Exception(str)__ is a replacement that works equally well in both Python 2 and Python 3.

__import sys__ and other minor cleanup.